### PR TITLE
adaptacja cartable na małe ekraniki 12.03.21

### DIFF
--- a/html/cartable.html
+++ b/html/cartable.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AutoBook - Samochody</title>
-    <link rel="stylesheet" href="../style/cartable.css">
+    <link rel="stylesheet" href="../style/cartable1.css">
 </head>
 <body style="background: white;">
     <header>

--- a/style/cartable1.css
+++ b/style/cartable1.css
@@ -1,0 +1,356 @@
+@font-face{
+    font-family: Mukata;
+    src: url("../img/Mukta-Medium.ttf");
+}
+
+body {
+    padding: 0;
+    margin: 0;
+    font-family: Mukata;
+    width: 100%;
+    height: 100%;
+    user-select: none; /* supported by Chrome and Opera */
+   -webkit-user-select: none; /* Safari */
+   -khtml-user-select: none; /* Konqueror HTML */
+   -moz-user-select: none; /* Firefox */
+   -ms-user-select: none;
+}
+
+header {
+    width: 100%;
+    background-color: black;
+    color:white;
+    font-size: 70px;
+    line-height: 120px;
+}
+
+#logo {
+    height: 100px;
+    margin-bottom: 10px;
+    margin-right: 15px;
+    margin-top: 10px;
+    margin-left: 20px;
+    float: left;
+}
+
+#profile_image {
+    float: right;
+    width: 70px;
+    height: 70px;
+    margin-top: 25px;
+    margin-right: 30px;
+}
+
+#list {
+    list-style-type: none;
+    color: black;
+    font-size: 18px;
+    border: 2px solid black ;
+    text-align: center;
+    display: none;
+    /*float: right;*/
+    /*width: 70px;*/
+    position: absolute;
+    z-index: 1;
+    background: white;
+    right: 17px;
+    top: 80px;
+    -moz-user-select: none; 
+    -webkit-user-select: none; 
+    -ms-user-select:none; 
+    user-select:none;
+    -o-user-select:none;
+}
+
+#list:hover {
+    cursor:pointer;
+}
+
+#list div:hover {
+    background: rgb(230, 230, 230);
+}
+
+#list span {
+    display: block;
+    text-align: center;
+    padding: 5px 5px 5px 5px;
+}
+
+#list div:before {
+    height: 1px;
+    width: 100%;
+    position: absolute;
+    transform: translateX(-49%);
+    left: 49%;
+    background: black;
+    content: "";
+    display: block;
+}
+
+#main {
+    width: 100%;
+    height: calc(100vh - 40px - 120px);
+}
+
+footer {
+    width: 100%;
+    height: 40px;
+    text-align: center;
+    color: white;
+    background: black;
+    line-height: 40px;
+}
+
+#service_table {
+    height: 500px;
+    border: 2px solid black;
+    clear: both;
+}
+
+#service_list_element {
+    height: 540px;
+    width: 1000px;
+    margin-top: 50px;
+    margin-left: 25%;
+    float: left;
+}
+
+[id^="search_"] {
+    background: black;
+    margin-bottom: 10px;
+    float: right;
+    margin-left: 20px;
+}
+
+.add_button {
+    float: left;
+    background: black;
+    color: white;
+    height: 30px;
+    padding: 10px 40px 10px 40px;
+    font-size: 20px;
+    margin-bottom: 10px;
+    margin-left: 5px;
+    margin-right: 0;
+}
+
+.add_button:hover, #search_button:hover, #search_filter:hover, .row:hover {
+    cursor: pointer;
+}
+
+
+#search_button {
+    width: 35px;
+    height: 35px;
+    padding-top: 5px;
+    padding-left: 5px;
+}
+
+#search_text {
+    border: none;
+    border-bottom: 2px solid black;
+    width: 170px;
+    height: 35px;
+    padding-left:10px;
+    background: white;
+    float: right;
+    font-size: 18px;;
+}
+
+#search_text:focus {
+    border: none;
+    outline: none;
+    border-bottom: 3px solid black;
+    background:rgb(230, 230, 230);
+}
+
+#search_text:hover {
+    border-bottom: 3px solid black;
+}
+
+#search_filter, #add {
+    height: 30px;
+    color: white;
+    padding: 5px 40px 5px 40px;
+    font-size: 20px;
+}
+
+#table_header {
+    background: black;
+    height: 40px;
+    color: white;
+    line-height: 40px;
+    font-size: 18px;
+    padding-left: 30px;
+}
+
+#table_header_make,  #table_header_gen, #table_header_year {
+    float: left;
+    width: 10%;
+    text-align: center;
+}
+
+#table_header_model {
+    float: left;
+    width: 20%;
+    text-align: center;
+}
+
+#table_header_vin {
+    float: left;
+    width: 35%;
+    text-align: center;
+}
+#table_header_rej {
+    float: left;
+    width: 15%;
+    text-align: center;
+}
+
+.row {
+    height: 40px;
+    border-top: 2px solid transparent;
+    border-bottom: 2px solid transparent;
+    line-height: 40px;
+    padding-left: 30px;
+    font-size: 18px;
+}
+
+.row:hover {
+    border-top: 2px solid black;
+    border-bottom: 2px solid black;
+}
+
+.row:nth-child(2n){
+    background: rgb(230, 230, 230);
+}
+
+.row div {
+    float: left;
+    text-align: center;
+}
+
+#make, #gen, #year {
+    width: 10%;
+}
+
+#model {
+    width: 20%;
+}
+
+#vin {
+    width: 35%;
+}
+
+#rej {
+    width: 15%;
+}
+
+.description_button {
+    float: left;
+    background: black;
+    color: white;
+    height: 30px;
+    padding: 5px 40px 5px 40px;
+    font-size: 20px;
+    margin-bottom: 10px;
+    margin-left: 0px;
+    margin-right: 0;
+}
+
+.description_button:hover {
+    cursor: pointer;
+}
+
+#hidden_form {
+    display: none;
+}
+
+@media only screen and (max-width: 520px) {
+   
+    header {
+        line-height: 60px;
+        padding: 0px;
+        height: 60px;
+        font-size: 25px;
+        margin-bottom: 12px;
+    }
+    #service_table {
+        height: 400px;
+        border: 2px solid black;
+        clear: both;
+    }
+    
+    #table_header {
+        background: black;
+        height: 20px;
+        color: white;
+        line-height: 20px;
+        font-size: 10px;
+        padding-left: 0px;
+    }
+    .row {
+        height: 20px;
+        border-top: 2px solid transparent;
+        border-bottom: 2px solid transparent;
+        line-height: 20px;
+        padding-left: 0px;
+        font-size: 9px;
+    }
+    #search_filter, #add {
+        margin: 2px;
+        color: white;
+        padding: 5px 5px 5px 5px;
+        font-size: 10px;
+        
+    }
+    #search_text {
+        margin-top: 12px;
+        border: none;
+        border-bottom: 2px solid black;
+        width: 80px;
+        height: 25px;
+        padding-left: 8px;
+        background: white;
+        float: right;
+        font-size: 9px;
+    }
+    
+    #service_list_element {
+        width: 100%;
+        margin: auto;
+        float: left;
+    }
+
+    footer {
+        height: 25px;
+        font-size: 10px;
+        line-height: 25px;
+    }
+    #profile{
+        float: right;
+        height: 50px;
+        margin-bottom: 5px;
+        margin-right: 7px;
+        margin-top: 5px;
+        margin-left: 10px;
+    }
+    #logo {
+        height: 50px;
+        margin-bottom: 5px;
+        margin-right: 7px;
+        margin-top: 5px;
+        margin-left: 10px;
+        float: left;
+    }
+
+    #main {
+        height: calc(100vh - 25px - 70px);
+    }
+}
+
+@media only screen and (max-height: 600px){
+    #main {
+        height: 600px;
+    }
+}


### PR DESCRIPTION
-tabelka sie skaluje na malym ekranie na cala szerokosc
-zmniejszony header+logo+prof+span
-footer na dole poprawiony zeby byl na samym dole ekranu bez przewijania
-czczionka 9px ale mozna pomyslec o ewentualnym powiekszeniu(sprawdz na tel, i powiedz czy wieksza dac czy jak)
-css zmieniony na cartable1.css ale stary jest dalej w razie jakby cos tam nie pykalo (hihi)